### PR TITLE
A few suggested improvements

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -15,20 +15,20 @@ RUN addgroup consul && \
 
 # Set up certificates, our base tools, and Consul.
 RUN apk add --no-cache ca-certificates gnupg && \
-    gpg --recv-keys 51852D87348FFC4C && \
+    gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
     wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
     wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig && \
-    gpg --verify docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
     grep ${DOCKER_BASE_VERSION}_linux_amd64.zip docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
-    cp bin/gosu bin/dumb-init /bin && \
+    cp bin/gosu /bin && \
     wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS.sig && \
-    gpg --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig consul_${CONSUL_VERSION}_SHA256SUMS && \
     grep consul_${CONSUL_VERSION}_linux_amd64.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin consul_${CONSUL_VERSION}_linux_amd64.zip && \
     cd /tmp && \
@@ -72,8 +72,8 @@ EXPOSE 8400 8500 8600 8600/udp
 # Consul doesn't need root privileges so we run it as the consul user from the
 # entry point script. The entry point script also uses dumb-init as the top-level
 # process to reap any zombie processes created by Consul sub-processes.
-COPY entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # By default you'll get a single-node development server that stores everything
 # in RAM, exposes a web UI, and bootstraps itself. Don't use this configuration

--- a/0.6/entrypoint.sh
+++ b/0.6/entrypoint.sh
@@ -1,10 +1,5 @@
-#!/bin/dumb-init /bin/sh
+#!/bin/sh
 set -e
-
-# Note above that we run dumb-init as PID 1 in order to reap zombie processes
-# as well as forward signals to all processes in its session. Normally, sh
-# wouldn't do either of these functions so we'd leak zombies as well as do
-# unclean termination of all our sub-processes.
 
 # You can set CONSUL_BIND_INTERFACE to the name of the interface you'd like to
 # bind to and this will look up the IP and pass the proper -bind= option along
@@ -55,7 +50,7 @@ fi
 # the Consul modes isn't selected).
 if [ "$1" = 'dev' ]; then
     shift
-    gosu consul \
+    exec gosu consul \
         consul agent \
          -dev \
          -config-dir="$CONSUL_CONFIG_DIR/local" \
@@ -64,7 +59,7 @@ if [ "$1" = 'dev' ]; then
          "$@"
 elif [ "$1" = 'client' ]; then
     shift
-    gosu consul \
+    exec gosu consul \
         consul agent \
          -data-dir="$CONSUL_DATA_DIR" \
          -config-dir="$CONSUL_CONFIG_DIR/client" \
@@ -74,7 +69,7 @@ elif [ "$1" = 'client' ]; then
          "$@"
 elif [ "$1" = 'server' ]; then
     shift
-    gosu consul \
+    exec gosu consul \
         consul agent \
          -server \
          -data-dir="$CONSUL_DATA_DIR" \


### PR DESCRIPTION
- use the full gpg fingerprint on import
- use `--batch` on `gpg --verify` (https://github.com/docker-library/official-images/pull/1420#issuecomment-189535397)
- add entrypoint.sh to the PATH as docker-entrypoint.sh
- use `exec` so that the shell does not stay resident
- remove `dumb-init`
  - I might be wrong here and can easily revert this change. From [consul documentation](https://www.consul.io/docs/agent/options.html#reap) under reap, it says that it does "reaping of child processes"; was there another reason to include it?  I thought that the resident `sh` process was getting in the way since you were missing `exec` (and the output of `consul` while testing this change seems to confirm that: `[DEBUG] Automatically reaping child processes`).

Feel free to tell me where I am wrong. :smile:

Also, I'd like to ask about the semi-complicated `dev`, `client`, `server` thing.  Is this what consul users would be used to seeing when running it outside of docker?  There doesn't seem to be much difference in the provided config file.  Would it be easier to allow a `RETRY_JOIN` space separated list to be passed in and use that to determine whether or not this is the initial bootstrap node or just tell users to run the server with something like `docker run -d consul -retry-join 'dns-name' -retry-join 'dns2-name'`

One more point: for `CONSUL_BIND` why not just default to `0.0.0.0`?  (I'm trying to understand the use case where a user would know the interface device name ahead of time, since I am not sure how deterministic joining two docker networks is.)