### PR TITLE
Allow CONSUL_DATA_DIR to be provided at runtime

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER James Phillips <james@hashicorp.com> (@slackpad)
 # This is the release of Consul to pull in.
 ENV CONSUL_VERSION=0.6.4
 
+# Allow paths to be overridden at runtime
+ENV CONSUL_DATA_DIR=/consul/data
+ENV CONSUL_CONFIG_DIR=/consul/config
+
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
 ENV DOCKER_BASE_VERSION=0.0.4

--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -40,8 +40,13 @@ fi
 # CONSUL_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use CONSUL_LOCAL_CONFIG
 # below.
-CONSUL_DATA_DIR=/consul/data
-CONSUL_CONFIG_DIR=/consul/config
+if [ -z "$CONSUL_DATA_DIR" ]; then
+    CONSUL_DATA_DIR=/consul/data
+fi
+
+if [ -z "$CONSUL_CONFIG_DIR" ]; then
+    CONSUL_CONFIG_DIR=/consul/config
+fi
 
 # You can also set the CONSUL_LOCAL_CONFIG environemnt variable to pass some
 # Consul configuration JSON without having to bind any volumes.


### PR DESCRIPTION
The use case I have is that I'd like to ship a Consul container that contains a set of predefined "fixtures" (i.e. the container comes with data already loaded into the K/V store). To do so, I `FROM` this image, add the fixtures, gracefully shut down and commit/tag/push.

However, `/consul/data` is a volume, so this doesn't work (see docker/docker#3639). That much is fairly obvious.

So, then I started looking for ways to use this container, but not use the `VOLUME`. docker/docker#8177 failed on code review (the maintainers seem to think this use case doesn't exist), so there's no way to directly opt out of the volume per se.

So, the next idea was just to modify where Consul was writing data in the downstream container. Unfortunately, because of the way this container's entrypoint is written (it always overwrites CONSUL_DATA_DIR), that isn't possible either.

This PR would allow CONSUL_DATA_DIR and CONSUL_CONFIG_DIR to be changed at runtime, allowing Consul to optionally write to the graphdriver-provided filesystem, rather than only a volume.