### PR TITLE
Updates Alpine to 3.4

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 MAINTAINER James Phillips <james@hashicorp.com> (@slackpad)
 
 # This is the release of Consul to pull in.


### PR DESCRIPTION
The latest version of Alpine resolves the issue with using `ping` as non-root
user.

Additional information found here:
http://alpinelinux.org/posts/Alpine-3.4.0-released.html

fixes: #17