### PR TITLE
Chown data and config before gosu

### DIFF
--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -75,6 +75,15 @@ fi
 
 # If we are running Consul, make sure it executes as the proper user.
 if [ "$1" = 'consul' ]; then
+    # If the data or config dirs are bind mounted then chown them.
+    # Note: This checks for root ownership as that's the most common case.
+    if [ "$(stat -c %u /consul/data)" = '0' ]; then
+      chown consul:consul /consul/data
+    fi
+    if [ "$(stat -c %u /consul/config)" = '0' ]; then
+      chown consul:consul /consul/config
+    fi
+
     set -- gosu consul "$@"
 fi
 


### PR DESCRIPTION
Fixes #20 

There's a decision to be made here.  I've gone with a conservative approach where we only chown `/consul/data` and `/consul/config` if they are owned by container's `root`.  This fixes the case where the host mount location is owned by root or dynamically created by `docker run` when run as `root`.

There are two other options:
1. Always chown.
2. Never chown and instead print a BIG FAT WARNING and exit.

I verified this patch by running this as `root` in `/root` without the patch.  I received the permission denied error as in #20.  I then built with the patch applied and the container started.