### PR TITLE
Fix binding privileged ports as consul user

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup consul && \
     adduser -S -G consul consul
 
 # Set up certificates, our base tools, and Consul.
-RUN apk add --no-cache ca-certificates gnupg openssl && \
+RUN apk add --no-cache ca-certificates gnupg openssl libcap && \
     gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
@@ -31,6 +31,7 @@ RUN apk add --no-cache ca-certificates gnupg openssl && \
     gpg --batch --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig consul_${CONSUL_VERSION}_SHA256SUMS && \
     grep consul_${CONSUL_VERSION}_linux_amd64.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    setcap 'cap_net_bind_service=+ep' /bin/consul && \
     cd /tmp && \
     rm -rf /tmp/build && \
     apk del gnupg openssl && \


### PR DESCRIPTION
Listening on TCP/UDP ports below _1024_ require to be the root user or to have the _CAP_NET_BIND_SERVICE_ Linux capability.
Currently Consul is run as the consul user. As an example when a privileged port is configured for DNS, the following error is reported upon container start:

> ==> Starting Consul agent...
> ==> Starting Consul agent RPC...
> ==> Error starting dns server: dns udp setup failed: listen udp 0.0.0.0:53: bind: permission denied

This commit grants the _CAP_NET_BIND_SERVICE_ capability to the **/bin/consul** binary.

This issue is also reported here: https://github.com/docker/docker/issues/8460