### PR TITLE
Optimize image size through simplicity

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -4,36 +4,32 @@ MAINTAINER James Phillips <james@hashicorp.com> (@slackpad)
 # This is the release of Consul to pull in.
 ENV CONSUL_VERSION=0.6.4
 
-# This is the release of https://github.com/hashicorp/docker-base to pull in order
-# to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
-ENV DOCKER_BASE_VERSION=0.0.4
-
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.
 RUN addgroup consul && \
     adduser -S -G consul consul
 
 # Set up certificates, our base tools, and Consul.
-RUN apk add --no-cache ca-certificates gnupg openssl && \
+RUN echo '@testing http://dl-4.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
+    apk add --update --no-cache \
+        ca-certificates \
+        dumb-init@testing \
+        su-exec && \
+    apk add --no-cache --virtual .build-deps \
+         gnupg \
+         openssl && \
     gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
-    wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
-    wget https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig && \
-    gpg --batch --verify docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
-    grep ${DOCKER_BASE_VERSION}_linux_amd64.zip docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
-    cp bin/gosu bin/dumb-init /bin && \
     wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS.sig && \
     gpg --batch --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig consul_${CONSUL_VERSION}_SHA256SUMS && \
     grep consul_${CONSUL_VERSION}_linux_amd64.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
     unzip -d /bin consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    apk del .build-deps && \
     cd /tmp && \
     rm -rf /tmp/build && \
-    apk del gnupg openssl && \
     rm -rf /root/.gnupg
 
 # The /consul/data dir is used by Consul to store state. The agent will be started

--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/dumb-init /bin/sh
+#!/usr/bin/dumb-init /bin/sh
 set -e
 
 # Note above that we run dumb-init as PID 1 in order to reap zombie processes
@@ -75,7 +75,7 @@ fi
 
 # If we are running Consul, make sure it executes as the proper user.
 if [ "$1" = 'consul' ]; then
-    set -- gosu consul "$@"
+    set -- su-exec consul "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Convert from gosu (~1.8MB) to su-exec (~20KB)
Install dumb-init alpine package that is statically linked with musl
which reduces from 700kb with glibc to 40KB.

Current
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
62f109a3299c        3 weeks ago         /bin/sh -c #(nop) CMD ["agent" "-dev"]          0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) ENTRYPOINT &{["docker-entry   0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) COPY file:1e4bc1007648fa04f   3.081 kB
<missing>           3 weeks ago         /bin/sh -c #(nop) EXPOSE 8400/tcp 8500/tcp 86   0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) EXPOSE 8301/tcp 8301/udp 83   0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) EXPOSE 8300/tcp               0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) VOLUME [/consul/data]         0 B
<missing>           3 weeks ago         /bin/sh -c mkdir -p /consul/data &&     mkdir   0 B
<missing>           3 weeks ago         /bin/sh -c apk add --no-cache ca-certificates   27.62 MB
<missing>           3 weeks ago         /bin/sh -c addgroup consul &&     adduser -S    8.652 MB
<missing>           3 weeks ago         /bin/sh -c #(nop) ENV DOCKER_BASE_VERSION=0.0   0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) ENV CONSUL_VERSION=0.6.4      0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) MAINTAINER James Phillips <   0 B
<missing>           3 weeks ago         /bin/sh -c #(nop) ADD file:86864edb9037700501   4.797 MB
```

New
```
$ docker history 7cfd60eb8b18
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
7cfd60eb8b18        8 minutes ago       /bin/sh -c #(nop) CMD ["agent" "-dev"]          0 B
083b1429748f        8 minutes ago       /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypo   0 B
86d82812fc04        8 minutes ago       /bin/sh -c #(nop) COPY file:44647909c53ee7c60   3.088 kB
18e76dec2afd        19 minutes ago      /bin/sh -c #(nop) EXPOSE 8400/tcp 8500/tcp 86   0 B
21bd1e38ec0b        19 minutes ago      /bin/sh -c #(nop) EXPOSE 8301/tcp 8301/udp 83   0 B
c6070cdab264        19 minutes ago      /bin/sh -c #(nop) EXPOSE 8300/tcp               0 B
ab0bfa380eb7        19 minutes ago      /bin/sh -c #(nop) VOLUME [/consul/data]         0 B
0be9753581ab        19 minutes ago      /bin/sh -c mkdir -p /consul/data &&     mkdir   0 B
1afe02d47496        19 minutes ago      /bin/sh -c echo '@testing http://dl-4.alpinel   24.89 MB
1a0f2c5b2beb        22 minutes ago      /bin/sh -c addgroup consul &&     adduser -S    4.956 kB
3cc2b19c4b96        22 minutes ago      /bin/sh -c #(nop) ENV CONSUL_VERSION=0.6.4      0 B
1166506aafc8        22 minutes ago      /bin/sh -c #(nop) MAINTAINER James Phillips <   0 B
4e38e38c8ce0        3 weeks ago         /bin/sh -c #(nop) ADD file:852e9d0cb9d906535a   4.799 MB
```

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
<none>              <none>              7cfd60eb8b18        9 minutes ago       29.69 MB
consul              v0.6.4              62f109a3299c        3 weeks ago         41.07 MB
```