### PR TITLE
Updating Dockerfile to include curl

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup consul && \
     adduser -S -G consul consul
 
 # Set up certificates, our base tools, and Consul.
-RUN apk add --no-cache ca-certificates gnupg openssl && \
+RUN apk add --no-cache ca-certificates gnupg openssl curl && \
     gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \


### PR DESCRIPTION
The reason for adding Curl is so that tools like https://github.com/AcalephStorage/consul-alerts can work off the bat.