### PR TITLE
File ownership based on consul user's id

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -77,10 +77,10 @@ fi
 if [ "$1" = 'consul' ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u /consul/data)" = '0' ]; then
+    if [ "$(stat -c %u /consul/data)" != "$(id -u consul)" ]; then
         chown consul:consul /consul/data
     fi
-    if [ "$(stat -c %u /consul/config)" = '0' ]; then
+    if [ "$(stat -c %u /consul/config)" != "$(id -u consul)" ]; then
         chown consul:consul /consul/config
     fi
 


### PR DESCRIPTION
A very minor change:
Instead of checking if the directory is owned by root, check if it's _not_ owned by consul before changing it.
This could prevent future problems if Alpine changes or is swapped for something else and the UID ends up not being 100.