### PR TITLE
Adding recursive chown to data/config dirs

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -78,10 +78,10 @@ if [ "$1" = 'consul' ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
     if [ "$(stat -c %u /consul/data)" != "$(id -u consul)" ]; then
-        chown consul:consul /consul/data
+        chown -R consul:consul /consul/data
     fi
     if [ "$(stat -c %u /consul/config)" != "$(id -u consul)" ]; then
-        chown consul:consul /consul/config
+        chown -R consul:consul /consul/config
     fi
 
     # If requested, set the capability to bind to privileged ports before


### PR DESCRIPTION
At startup, the script should recursively change ownership of files within the /consul/data and /consul/config paths. This allows one to add/mount health check scripts for instance into a sub path.
