### PR TITLE
Bump Consul to release version 0.8.0, bump alpine to 3.5 (latest)

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.4
+FROM alpine:3.5
 MAINTAINER James Phillips <james@hashicorp.com> (@slackpad)
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=0.7.5
+ENV CONSUL_VERSION=0.8.0
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.


### PR DESCRIPTION
Bumped Consul and and alpine to latest stable.