### PR TITLE
Add warning to docker-entrypoint.sh if -data-dir or -config-dir is used

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -57,6 +57,18 @@ fi
 
 # Look for Consul subcommands.
 if [ "$1" = 'agent' ]; then
+    args="$@"
+
+    if [ ! -z "${args##*$-config-dir*}" ]; then
+        echo "Warn: consul ran with -config-dir. docker-consul's official image does not support this parameter by default. You may encounter permission issues.
+      See: https://github.com/hashicorp/docker-consul/issues/74"
+    fi
+
+    if [ ! -z "${args##*$-data-dir*}" ]; then
+        echo "Warn: consul ran with -data-dir. docker-consul's official image does not support this parameter by default. You may encounter permission issues.
+      See: https://github.com/hashicorp/docker-consul/issues/74"
+    fi
+
     shift
     set -- consul agent \
         -data-dir="$CONSUL_DATA_DIR" \

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -58,13 +58,15 @@ fi
 # Look for Consul subcommands.
 if [ "$1" = 'agent' ]; then
     args="$@"
+    configstr="config-dir"
+    datastr="data-dir"
 
-    if [ ! -z "${args##*$-config-dir*}" ]; then
+    if [ -z "${args##*$configstr*}" ]; then
         echo "Warn: consul ran with -config-dir. docker-consul's official image does not support this parameter by default. You may encounter permission issues.
       See: https://github.com/hashicorp/docker-consul/issues/74"
     fi
 
-    if [ ! -z "${args##*$-data-dir*}" ]; then
+    if [ -z "${args##*$datastr*}" ]; then
         echo "Warn: consul ran with -data-dir. docker-consul's official image does not support this parameter by default. You may encounter permission issues.
       See: https://github.com/hashicorp/docker-consul/issues/74"
     fi


### PR DESCRIPTION
This PR adds a warning that can help people running into permission issues when using `-data-dir`  or `-config-dir` in their docker-compose or `docker run...` setups.

I will admit, I did try to get the script to read the args, create necessary subdirectories, chown..., etc., but I'm not sure if that logic really belongs in a `dockerfile-entrypoint.sh` or within consul itself. I believe this will clear up a lot of confusion in the meantime. :)  

Addresses #74 
Relates to #20 