### PR TITLE
Add multiarch support based on available release binaries

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -13,20 +13,31 @@ RUN addgroup consul && \
     adduser -S -G consul consul
 
 # Set up certificates, base tools, and Consul.
-RUN apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec && \
+RUN set -eux && \
+    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    apkArch="$(apk --print-arch)" && \
+    case "${apkArch}" in \
+        aarch64) consulArch='arm64' ;; \
+        armhf) consulArch='arm' ;; \
+        x86) consulArch='386' ;; \
+        x86_64) consulArch='amd64' ;; \
+        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/)" && exit 1 ;; \
+    esac && \
+    wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_${consulArch}.zip && \
     wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS && \
     wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS.sig && \
     gpg --batch --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig consul_${CONSUL_VERSION}_SHA256SUMS && \
-    grep consul_${CONSUL_VERSION}_linux_amd64.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /bin consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    grep consul_${CONSUL_VERSION}_linux_${consulArch}.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /bin consul_${CONSUL_VERSION}_linux_${consulArch}.zip && \
     cd /tmp && \
     rm -rf /tmp/build && \
     apk del gnupg openssl && \
-    rm -rf /root/.gnupg
+    rm -rf /root/.gnupg && \
+# tiny smoke test to ensure the binary we downloaded runs
+    consul version
 
 # The /consul/data dir is used by Consul to store state. The agent will be started
 # with /consul/config as the configuration directory so you can add additional


### PR DESCRIPTION
Fixes #67

@slackpad any idea what the value of `GOARM` was when building the `consul_1.0.3_linux_arm.zip` binary that's on https://releases.hashicorp.com/consul/1.0.3/ ?

(or anyone with an `arm32v6` Raspberry Pi 1 or Zero willing to try running that binary for me and tell me if it errors?)