### PR TITLE
Bump to 1.0.7

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Preetha Appan <preetha@hashicorp.com> (@preetapan)
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=1.0.6
+ENV CONSUL_VERSION=1.0.7
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com


### PR DESCRIPTION
Noticed in my log that 1.0.7 was released. Is this all that is needed for the docker container to get updated?