### PR TITLE
Added /etc/nsswitch.conf file so container's hosts file is respected by Consul - fixes #94

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -46,6 +46,10 @@ RUN mkdir -p /consul/data && \
     mkdir -p /consul/config && \
     chown -R consul:consul /consul
 
+# set up nsswitch.conf for Go's "netgo" implementation which is used by Consul,
+# otherwise DNS supercedes the container's hosts file, which we don't want.
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 # Expose the consul data directory as a volume since there's mutable state in there.
 VOLUME /consul/data
 

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /consul/data && \
 
 # set up nsswitch.conf for Go's "netgo" implementation which is used by Consul,
 # otherwise DNS supercedes the container's hosts file, which we don't want.
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 
 # Expose the consul data directory as a volume since there's mutable state in there.
 VOLUME /consul/data


### PR DESCRIPTION
The image did not include `/etc/nsswitch.conf`, and so hostname resolution was using DNS before checking `/etc/hosts`. This commit fixes that.

See https://github.com/hashicorp/docker-consul/issues/94