### PR TITLE
Use HKPS for receiving GPG key over TLS

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -15,7 +15,7 @@ RUN addgroup consul && \
 # Set up certificates, base tools, and Consul.
 RUN set -eux && \
     apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec && \
-    gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
+    gpg --keyserver hkps://pgp.mit.edu:443 --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
     apkArch="$(apk --print-arch)" && \


### PR DESCRIPTION
Right now the GPG key is received over plain tcp + HTTP. This will force the GPG command to receive the key over HKPS which uses TLS.