### PR TITLE
chown all subdir under /consul/data and /consul/config

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Preetha Appan <preetha@hashicorp.com> (@preetapan)
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=1.2.2
+ENV CONSUL_VERSION=1.2.3
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -79,10 +79,10 @@ if [ "$1" = 'consul' ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
     if [ "$(stat -c %u /consul/data)" != "$(id -u consul)" ]; then
-        chown consul:consul /consul/data
+        chown consul:consul -R /consul/data
     fi
     if [ "$(stat -c %u /consul/config)" != "$(id -u consul)" ]; then
-        chown consul:consul /consul/config
+        chown consul:consul -R /consul/config
     fi
 
     # If requested, set the capability to bind to privileged ports before


### PR DESCRIPTION
Just refer to vault's docker-entrypoint.sh, this would be convenient if put tls certs and key files under /consul/config volumes.
