### PR TITLE
Fix issue with ping not working within script checks

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup consul && \
 
 # Set up certificates, base tools, and Consul.
 RUN set -eux && \
-    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec && \
+    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \


### PR DESCRIPTION
Fixes: #17 

`/bin/ping` in alpine is normally a symlink to `/bin/busybox`. On other distros `/bin/ping` is a setuid binary to allow ICMP sockets to work for regular users.

So there were 3 options:

1 - `chmod u+s /bin/ping`
2 - Install a ping binary not associated with busybox
3 - Require users to configure the host linux to allow GID 1000 the ability to ping (sysctl net.ipv4.ping_group_range)

Number 1 would be terribly insecure as it actually makes the entire `/bin/busybox` binary setuid and almost every command in `/bin` is actually just a symlink to `/bin/busybox`. Number 3 puts the burden of configuration on the user and isn't a wonderful UX. Number 2 however only has the downsides of including a few extra binaries in the image. The size becomes a little larger but not by much.

Therefore the iputils package was installed which provides real ping and ping6 binaries in addition to a handful of other utilities such as traceroute.