### PR TITLE
Backport Versions

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Consul Team <consul@hashicorp.com>
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=0.9.4
+ENV CONSUL_VERSION=1.0.8
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Consul Team <consul@hashicorp.com>
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=1.0.8
+ENV CONSUL_VERSION=1.1.1
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Consul Team <consul@hashicorp.com>
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=1.4.0
+ENV CONSUL_VERSION=0.9.4
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com

--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Consul Team <consul@hashicorp.com>
 
 # This is the release of Consul to pull in.
-ENV CONSUL_VERSION=1.1.1
+ENV CONSUL_VERSION=1.2.4
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com


### PR DESCRIPTION
We'll reference these specific sha's elsewhere. This should not be squashed.

We released [backports](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/consul-tool/kmGKTj3YxUg) for a security incident and need specific shas to reference for these versions in order to update the official docker-images manifest.