### PR TITLE
add timezone support

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup consul && \
 
 # Set up certificates, base tools, and Consul.
 RUN set -eux && \
-    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq && \
+    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq tzdata && \
     gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \


### PR DESCRIPTION
There is no ability to set timezone for consul docker container.
Add tzdata package, then the container can accept TZ env variable to set timezone.
Example:
```
docker run -e "TZ=Europe/Moscow" --rm consul date
```