### PR TITLE
Add capability to disable user and permission management with env var

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -75,7 +75,7 @@ elif consul --help "$1" 2>&1 | grep -q "consul $1"; then
 fi
 
 # If we are running Consul, make sure it executes as the proper user.
-if [ "$1" = 'consul' ]; then
+if [ "$1" = 'consul' -a -z "${CONSUL_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
     if [ "$(stat -c %u /consul/data)" != "$(id -u consul)" ]; then


### PR DESCRIPTION
This allows the container to be run in a mode where we don't drop to the consul user and do not perform chown on the data/conf directories and do not ever try to enable privileged port binding.

Essentially using the env var opts you out of all the permission type things and you now need to manage it yourself.

It can now be run like:

`docker run -e CONSUL_DISABLE_PERM_MGMT= consul:latest`

Without specifying the new environment variable the previous behavior will be used.

The main use case for this is around executing the container as non-root. The user running the container will then need to ensure that the permissions on the data directory and the config directory allow the user running the container access.