### PR TITLE
Stop gpg deamons

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -35,6 +35,7 @@ RUN set -eux && \
     unzip -d /bin consul_${CONSUL_VERSION}_linux_${consulArch}.zip && \
     cd /tmp && \
     rm -rf /tmp/build && \
+    gpgconf --kill all && \
     apk del gnupg openssl && \
     rm -rf /root/.gnupg && \
 # tiny smoke test to ensure the binary we downloaded runs


### PR DESCRIPTION
Sometimes the gpg directory cannot be removed and this should take care
of it by killing all the running gpg deamons. This is what it looks like
if it fails:

```
(23/23) Purging sqlite-libs (3.28.0-r3)
Executing busybox-1.29.3-r10.trigger
OK: 9 MiB in 25 packages
+ rm -rf /root/.gnupg
rm: can't remove '/root/.gnupg/S.gpg-agent.browser': No such file or directory
Removing intermediate container aa9b1ae8718f
```

And this is where it happened:
https://github.com/docker-library/official-images/runs/663648218.

Credit to @tianon:
https://github.com/docker-library/official-images/pull/7976#issuecomment-626748203.