### PR TITLE
Update alpine version

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.9
-MAINTAINER Consul Team <consul@hashicorp.com>
+FROM alpine:3.12
+LABEL maintainer="Consul Team <consul@hashicorp.com>"
 
 # This is the release of Consul to pull in.
 ENV CONSUL_VERSION=1.8.0-rc1


### PR DESCRIPTION
Fixes #147

Also replace the MAINTAINER instruction with a label, as suggested by
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Tested with `docker build; docker run`, and it worked for linux/amd64 at least. How else should I test this?