### PR TITLE
Change Keyserver to sks-pool

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -16,7 +16,7 @@ RUN addgroup consul && \
 # libc6-compat is needed to symlink the shared libraries for ARM builds
 RUN set -eux && \
     apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat && \
-    gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
+    gpg --keyserver pool.sks-keyservers.net --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
     apkArch="$(apk --print-arch)" && \


### PR DESCRIPTION
Because pgp.mit.edu seems to be down for a lot of people, its probably better to switch to the sks-pool.

Looking at #137 I'm not the only one seeing this.