### PR TITLE
Allow passing arbitrary config data to consul container

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -43,6 +43,15 @@ fi
 # below.
 CONSUL_DATA_DIR=/consul/data
 CONSUL_CONFIG_DIR=/consul/config
+CONSUL_EXTRA_CONFIG_DIR=/consul/extra
+
+# CONSUL_EXTRA_CONFIG is a base64 encoded tar file. It's contents are extracted 
+# and can be referenced by configuration provided via CONSUL_LOCAL_CONFIG.
+# The purpose
+if [ -n "$CONSUL_EXTRA_CONFIG" ]; then
+  mkdir -p "$CONSUL_EXTRA_CONFIG_DIR"
+  echo "$CONSUL_EXTRA_CONFIG" | base64 -d | tar --extract --verbose --overwrite --directory "$CONSUL_EXTRA_CONFIG_DIR" --file -
+fi
 
 # You can also set the CONSUL_LOCAL_CONFIG environemnt variable to pass some
 # Consul configuration JSON without having to bind any volumes.

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -45,11 +45,11 @@ CONSUL_DATA_DIR=/consul/data
 CONSUL_CONFIG_DIR=/consul/config
 CONSUL_EXTRA_CONFIG_DIR=/consul/extra
 
-# CONSUL_EXTRA_CONFIG is a base64 encoded tar file. It's contents are extracted 
+# CONSUL_EXTRA_CONFIG is base64 encoded tar'ed data. It's contents are extracted 
 # and can be referenced by configuration provided via CONSUL_LOCAL_CONFIG.
-# The purpose
+# The purpose is to avoid dealing with volumes just for the sake of configuration.
+mkdir -p "$CONSUL_EXTRA_CONFIG_DIR"
 if [ -n "$CONSUL_EXTRA_CONFIG" ]; then
-  mkdir -p "$CONSUL_EXTRA_CONFIG_DIR"
   echo "$CONSUL_EXTRA_CONFIG" | base64 -d | tar --extract --verbose --overwrite --directory "$CONSUL_EXTRA_CONFIG_DIR" --file -
 fi
 
@@ -92,6 +92,9 @@ if [ "$1" = 'consul' -a -z "${CONSUL_DISABLE_PERM_MGMT+x}" ]; then
     fi
     if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "$(id -u consul)" ]; then
         chown consul:consul "$CONSUL_CONFIG_DIR"
+    fi
+    if [ "$(stat -c %u "$CONSUL_EXTRA_CONFIG_DIR")" != "$(id -u consul)" ]; then
+        chown --recursive consul:consul "$CONSUL_EXTRA_CONFIG_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before


### PR DESCRIPTION
This PR adds the ability to pass arbitrary data to the consul container via a new environment variable `CONSUL_EXTRA_CONFIG` for configuration purposes. 

Use case for this is that it allows to configure custom TLS (ca_/cert_/key_) file while avoiding the introduction of any persistence which needs to be maintained. This is e.g. beneficial when having consul running in AWS ECS as a side car as it allows to avoid the relatively complex overhead of an EFS volume while at the same time using the AWS secrets manager for storing the to be used secret data.

Command line example: 

```
ls extra/
consulAgent.ca.pem  consulAgent.crt  consulAgent.key
```

```
EXTRA_CONFIG=$(tar --create --directory=extra/ . | base64)
LOCAL_CONFIG=$(cat <<-EndOfContent
{
  "bind_addr": "10.0.0.3",
  "ca_file": "/consul/extra/consulAgent.ca.pem",
  "cert_file": "/consul/extra/consulAgent.crt",
  "key_file": "/consul/extra/consulAgent.key",
  "leave_on_terminate": true,
  "rejoin_after_leave": true,
  "retry_join": [
      "10.0.0.2"
   ],
  "server": false
}
EndOfContent
)

docker run --net=host \
  -e "CONSUL_LOCAL_CONFIG=${LOCAL_CONFIG}" \
  -e "CONSUL_EXTRA_CONFIG=${EXTRA_CONFIG}" \
  consul
```