### PR TITLE
Revert "switch to hashicorp docker mirror"

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/alpine:3.12
+FROM alpine:3.12
 LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>"
 
 # This is the release of Consul to pull in.


### PR DESCRIPTION
Reverts hashicorp/docker-consul#157 to avoid rejection in https://github.com/docker-library/official-images/pull/9041#issuecomment-723369880