### PR TITLE
Remove some hardcodes

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -41,8 +41,13 @@ fi
 # CONSUL_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use CONSUL_LOCAL_CONFIG
 # below.
-CONSUL_DATA_DIR=/consul/data
-CONSUL_CONFIG_DIR=/consul/config
+if [ -z "$CONSUL_DATA_DIR" ]; then
+  CONSUL_DATA_DIR=/consul/data
+fi
+
+if [ -z "$CONSUL_CONFIG_DIR" ]; then
+  CONSUL_CONFIG_DIR=/consul/config
+fi
 
 # You can also set the CONSUL_LOCAL_CONFIG environemnt variable to pass some
 # Consul configuration JSON without having to bind any volumes.
@@ -53,46 +58,55 @@ fi
 # If the user is trying to run Consul directly with some arguments, then
 # pass them to Consul.
 if [ "${1:0:1}" = '-' ]; then
-    set -- consul "$@"
+  set -- consul "$@"
 fi
 
 # Look for Consul subcommands.
 if [ "$1" = 'agent' ]; then
-    shift
-    set -- consul agent \
-        -data-dir="$CONSUL_DATA_DIR" \
-        -config-dir="$CONSUL_CONFIG_DIR" \
-        $CONSUL_BIND \
-        $CONSUL_CLIENT \
-        "$@"
+  shift
+  set -- consul agent \
+      -data-dir="$CONSUL_DATA_DIR" \
+      -config-dir="$CONSUL_CONFIG_DIR" \
+      $CONSUL_BIND \
+      $CONSUL_CLIENT \
+      "$@"
 elif [ "$1" = 'version' ]; then
-    # This needs a special case because there's no help output.
-    set -- consul "$@"
+  # This needs a special case because there's no help output.
+  set -- consul "$@"
 elif consul --help "$1" 2>&1 | grep -q "consul $1"; then
-    # We can't use the return code to check for the existence of a subcommand, so
-    # we have to use grep to look for a pattern in the help output.
-    set -- consul "$@"
+  # We can't use the return code to check for the existence of a subcommand, so
+  # we have to use grep to look for a pattern in the help output.
+  set -- consul "$@"
 fi
 
 # If we are running Consul, make sure it executes as the proper user.
 if [ "$1" = 'consul' -a -z "${CONSUL_DISABLE_PERM_MGMT+x}" ]; then
-    # If the data or config dirs are bind mounted then chown them.
-    # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u "$CONSUL_DATA_DIR")" != "$(id -u consul)" ]; then
-        chown consul:consul "$CONSUL_DATA_DIR"
-    fi
-    if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "$(id -u consul)" ]; then
-        chown consul:consul "$CONSUL_CONFIG_DIR"
-    fi
+  # Allow to setup user and group via envrironment
+  if [ -z "$CONSUL_USER" ]; then
+    CONSUL_USER="consul"
+  fi
 
-    # If requested, set the capability to bind to privileged ports before
-    # we drop to the non-root user. Note that this doesn't work with all
-    # storage drivers (it won't work with AUFS).
-    if [ ! -z ${CONSUL_ALLOW_PRIVILEGED_PORTS+x} ]; then
-        setcap "cap_net_bind_service=+ep" /bin/consul
-    fi
+  if [ -z "$CONSUL_GROUP" ]; then
+    CONSUL_GROUP="consul"
+  fi
 
-    set -- su-exec consul:consul "$@"
+  # If the data or config dirs are bind mounted then chown them.
+  # Note: This checks for root ownership as that's the most common case.
+  if [ "$(stat -c %u "$CONSUL_DATA_DIR")" != "$(id -u consul)" ]; then
+    chown ${CONSUL_USER}:${CONSUL_GROUP} "$CONSUL_DATA_DIR"
+  fi
+  if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "$(id -u consul)" ]; then
+    chown ${CONSUL_USER}:${CONSUL_GROUP} "$CONSUL_CONFIG_DIR"
+  fi
+
+  # If requested, set the capability to bind to privileged ports before
+  # we drop to the non-root user. Note that this doesn't work with all
+  # storage drivers (it won't work with AUFS).
+  if [ ! -z ${CONSUL_ALLOW_PRIVILEGED_PORTS+x} ]; then
+    setcap "cap_net_bind_service=+ep" /bin/consul
+  fi
+
+  set -- su-exec ${CONSUL_USER}:${CONSUL_GROUP} "$@"
 fi
 
 exec "$@"

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -92,10 +92,10 @@ if [ "$1" = 'consul' -a -z "${CONSUL_DISABLE_PERM_MGMT+x}" ]; then
 
   # If the data or config dirs are bind mounted then chown them.
   # Note: This checks for root ownership as that's the most common case.
-  if [ "$(stat -c %u "$CONSUL_DATA_DIR")" != "$(id -u consul)" ]; then
+  if [ "$(stat -c %u "$CONSUL_DATA_DIR")" != "$(id -u ${CONSUL_USER})" ]; then
     chown ${CONSUL_USER}:${CONSUL_GROUP} "$CONSUL_DATA_DIR"
   fi
-  if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "$(id -u consul)" ]; then
+  if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "$(id -u ${CONSUL_USER})" ]; then
     chown ${CONSUL_USER}:${CONSUL_GROUP} "$CONSUL_CONFIG_DIR"
   fi
 

--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -65,11 +65,11 @@ fi
 if [ "$1" = 'agent' ]; then
   shift
   set -- consul agent \
-      -data-dir="$CONSUL_DATA_DIR" \
-      -config-dir="$CONSUL_CONFIG_DIR" \
-      $CONSUL_BIND \
-      $CONSUL_CLIENT \
-      "$@"
+    -data-dir="$CONSUL_DATA_DIR" \
+    -config-dir="$CONSUL_CONFIG_DIR" \
+    $CONSUL_BIND \
+    $CONSUL_CLIENT \
+    "$@"
 elif [ "$1" = 'version' ]; then
   # This needs a special case because there's no help output.
   set -- consul "$@"
@@ -82,21 +82,21 @@ fi
 # If we are running Consul, make sure it executes as the proper user.
 if [ "$1" = 'consul' -a -z "${CONSUL_DISABLE_PERM_MGMT+x}" ]; then
   # Allow to setup user and group via envrironment
-  if [ -z "$CONSUL_USER" ]; then
-    CONSUL_USER="consul"
+  if [ -z "$CONSUL_UID" ]; then
+    CONSUL_UID="$(id -u consul)"
   fi
 
-  if [ -z "$CONSUL_GROUP" ]; then
-    CONSUL_GROUP="consul"
+  if [ -z "$CONSUL_GID" ]; then
+    CONSUL_GID="$(id -g consul)"
   fi
 
   # If the data or config dirs are bind mounted then chown them.
   # Note: This checks for root ownership as that's the most common case.
-  if [ "$(stat -c %u "$CONSUL_DATA_DIR")" != "$(id -u ${CONSUL_USER})" ]; then
-    chown ${CONSUL_USER}:${CONSUL_GROUP} "$CONSUL_DATA_DIR"
+  if [ "$(stat -c %u "$CONSUL_DATA_DIR")" != "${CONSUL_UID}" ]; then
+    chown ${CONSUL_UID}:${CONSUL_GID} "$CONSUL_DATA_DIR"
   fi
-  if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "$(id -u ${CONSUL_USER})" ]; then
-    chown ${CONSUL_USER}:${CONSUL_GROUP} "$CONSUL_CONFIG_DIR"
+  if [ "$(stat -c %u "$CONSUL_CONFIG_DIR")" != "${CONSUL_UID}" ]; then
+    chown ${CONSUL_UID}:${CONSUL_GID} "$CONSUL_CONFIG_DIR"
   fi
 
   # If requested, set the capability to bind to privileged ports before
@@ -106,7 +106,7 @@ if [ "$1" = 'consul' -a -z "${CONSUL_DISABLE_PERM_MGMT+x}" ]; then
     setcap "cap_net_bind_service=+ep" /bin/consul
   fi
 
-  set -- su-exec ${CONSUL_USER}:${CONSUL_GROUP} "$@"
+  set -- su-exec ${CONSUL_UID}:${CONSUL_GID} "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This patch allow to set UID/GID via environments. This allow to use CONSUL_ALLOW_PRIVILEGED_PORTS and starting consul with uid/gid that passed for example from docker-compose. I've manage users via puppet outside of containers and need to start consul with UID/GID from puppet. Also I've added config and data dir configuration from environment and reindent docker-entrypoint.sh, because mix from spaces and tabs does not a good idea.