### PR TITLE
use oci spec pre-defined key for version

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>"
 
 # This is the release of Consul to pull in.
 ARG CONSUL_VERSION=1.9.2
-LABEL consul.version=$CONSUL_VERSION
+LABEL org.opencontainers.image.version=$CONSUL_VERSION
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com


### PR DESCRIPTION
https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys pre-defines `org.opencontainers.image.version` to use for versioning. consul-enterprise pre-release versions do not adhere quite to semver but the wording is `MAY` so this should suffice.

 Outside of the versioning we do ourselves, if we want to keep the docker tag consistent with `org.opencontainers.image.version` and in line with semver, this is currently not possible due to https://github.com/docker/distribution/issues/1201 where docker tags cannot take `+`. 