### PR TITLE
entrypoint: Don't clear CONSUL_BIND and CONSUL_CLIENT envvars at start

### DIFF
--- a/0.X/docker-entrypoint.sh
+++ b/0.X/docker-entrypoint.sh
@@ -10,31 +10,33 @@ set -e
 # You can set CONSUL_BIND_INTERFACE to the name of the interface you'd like to
 # bind to and this will look up the IP and pass the proper -bind= option along
 # to Consul.
-CONSUL_BIND=
-if [ -n "$CONSUL_BIND_INTERFACE" ]; then
-  CONSUL_BIND_ADDRESS=$(ip -o -4 addr list $CONSUL_BIND_INTERFACE | head -n1 | awk '{print $4}' | cut -d/ -f1)
-  if [ -z "$CONSUL_BIND_ADDRESS" ]; then
-    echo "Could not find IP for interface '$CONSUL_BIND_INTERFACE', exiting"
-    exit 1
-  fi
+if [ -z "$CONSUL_BIND" ]; then
+  if [ -n "$CONSUL_BIND_INTERFACE" ]; then
+    CONSUL_BIND_ADDRESS=$(ip -o -4 addr list $CONSUL_BIND_INTERFACE | head -n1 | awk '{print $4}' | cut -d/ -f1)
+    if [ -z "$CONSUL_BIND_ADDRESS" ]; then
+      echo "Could not find IP for interface '$CONSUL_BIND_INTERFACE', exiting"
+      exit 1
+    fi
 
-  CONSUL_BIND="-bind=$CONSUL_BIND_ADDRESS"
-  echo "==> Found address '$CONSUL_BIND_ADDRESS' for interface '$CONSUL_BIND_INTERFACE', setting bind option..."
+    CONSUL_BIND="-bind=$CONSUL_BIND_ADDRESS"
+    echo "==> Found address '$CONSUL_BIND_ADDRESS' for interface '$CONSUL_BIND_INTERFACE', setting bind option..."
+  fi
 fi
 
 # You can set CONSUL_CLIENT_INTERFACE to the name of the interface you'd like to
 # bind client intefaces (HTTP, DNS, and RPC) to and this will look up the IP and
 # pass the proper -client= option along to Consul.
-CONSUL_CLIENT=
-if [ -n "$CONSUL_CLIENT_INTERFACE" ]; then
-  CONSUL_CLIENT_ADDRESS=$(ip -o -4 addr list $CONSUL_CLIENT_INTERFACE | head -n1 | awk '{print $4}' | cut -d/ -f1)
-  if [ -z "$CONSUL_CLIENT_ADDRESS" ]; then
-    echo "Could not find IP for interface '$CONSUL_CLIENT_INTERFACE', exiting"
-    exit 1
-  fi
+if [ -z "$CONSUL_CLIENT" ]; then
+  if [ -n "$CONSUL_CLIENT_INTERFACE" ]; then
+    CONSUL_CLIENT_ADDRESS=$(ip -o -4 addr list $CONSUL_CLIENT_INTERFACE | head -n1 | awk '{print $4}' | cut -d/ -f1)
+    if [ -z "$CONSUL_CLIENT_ADDRESS" ]; then
+      echo "Could not find IP for interface '$CONSUL_CLIENT_INTERFACE', exiting"
+      exit 1
+    fi
 
-  CONSUL_CLIENT="-client=$CONSUL_CLIENT_ADDRESS"
-  echo "==> Found address '$CONSUL_CLIENT_ADDRESS' for interface '$CONSUL_CLIENT_INTERFACE', setting client option..."
+    CONSUL_CLIENT="-client=$CONSUL_CLIENT_ADDRESS"
+    echo "==> Found address '$CONSUL_CLIENT_ADDRESS' for interface '$CONSUL_CLIENT_INTERFACE', setting client option..."
+  fi
 fi
 
 # CONSUL_DATA_DIR is exposed as a volume for possible persistent storage. The


### PR DESCRIPTION
This change would allow users to specify the values for `CONSUL_BIND` and `CONSUL_CLIENT` via the environment variables.  This allows users to utilize more complex, dynamic auto-configuration for the binding interfaces via the supported [go-sockaddr template configuration](https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template) as documented [here](https://www.consul.io/docs/agent/options#_bind).

Such an example might be:

```
CONSUL_BIND='-bind {{ GetPrivateInterface }}'
```

or

```
CONSUL_BIND='-bind {{ GetAllInterfaces | include "name" "^eth" | include "flags" "forwardable|up" | attr "address" }}'
```

An important use case for this functionality is when running Consul on AWS ECS/Fargate. Fargate promises that containers will have a routable IP address in their VPC subnet, but it does not specify what the interface name will be; and the name has varied across (and sometimes within) Fargate platform versions. This has tripped up some customers who have created static configurations to make Consul bind to the `eth1` interface, when a more heuristics-based approach should be taken instead. 

Ideally, the bind IP address should be taken from the published [ECS task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html), but for now, we chose the least intrusive and most vendor-agnostic approach to solving the problem. We are open to publishing another PR to enable autoconfiguration on ECS, but wanted to hear back as to whether you'd be amenable to it first.