### PR TITLE
Add tar to UBI images

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -35,7 +35,7 @@ COPY LICENSE /licenses/mozilla.txt
 # Its shasum is hardcoded. If you upgrade the dumb-init verion you'll need to
 # also update the shasum.
 RUN set -eux && \
-    microdnf install -y ca-certificates curl gnupg libcap openssl iputils jq iptables wget unzip  && \
+    microdnf install -y ca-certificates curl gnupg libcap openssl iputils jq iptables wget unzip tar && \
     wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
     echo 'e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df /usr/bin/dumb-init' > dumb-init-shasum && \
     sha256sum --check dumb-init-shasum && \


### PR DESCRIPTION
tar is required for kubectl cp to work and it is also available in
Consul's regular images so makes sense to have it here.