### PR TITLE
Add suppoort for setting timezone

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -30,7 +30,7 @@ RUN addgroup consul && \
 # Set up certificates, base tools, and Consul.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
 RUN set -eux && \
-    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat iptables && \
+    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat iptables tzdata && \
     gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \


### PR DESCRIPTION
This supersedes #123 and makes the same change on an up-to-date base. 

This enables users to set timezone by doing:
```
docker run -e "TZ=Europe/Moscow" --rm consul date
```