### PR TITLE
UBI Image: bump to ubi-minimal:8.6

### DIFF
--- a/ubi/Dockerfile
+++ b/ubi/Dockerfile
@@ -9,7 +9,7 @@
 # This Dockerfile is different from the regular Dockerfile because it's
 # based on Red Hat's UBI image. This Dockerfile is used to build a Consul
 # image for use on OpenShift.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 # This is the release of Consul to pull in.
 ARG CONSUL_VERSION=1.10.0


### PR DESCRIPTION
Bumping for posterity, by the next core release we will likely be using the Dockerfile from https://github.com/hashicorp/consul/pull/13232/files